### PR TITLE
Fixes automatic selection of Audio devices

### DIFF
--- a/OBSControl/PluginConfig.cs
+++ b/OBSControl/PluginConfig.cs
@@ -550,19 +550,19 @@ namespace OBSControl
             get => ObsAudioDevices["mic-4"].deviceName;
             set => this.HandleAudioDeviceSelection("mic-4", value);
         }
-        private async void HandleAudioDeviceSelection(string sourceKey, string deviceName)
+        private async void HandleAudioDeviceSelection(string sourceKey, string shortDeviceName)
         {
-            Logger.log?.Debug($"|ADC| Handling \"{sourceKey}\" - \"{deviceName}\"");
+            Logger.log?.Debug($"|ADC| Handling \"{sourceKey}\" - \"{shortDeviceName}\"");
 
             ObsAudioDevices.TryGetValue(sourceKey, out AudioDeviceDropdownEntry oldDevice);
-            if (oldDevice.deviceName!= deviceName) {
-                await oldDevice.TrySetDevice(sourceKey, deviceName);
+            if (oldDevice.deviceName!= shortDeviceName) {
+                await oldDevice.TrySetDevice(sourceKey, shortDeviceName, sourceKey.StartsWith("desktop"));
             }
 
-            ObsAudioDevices[sourceKey].deviceName = deviceName;
+            ObsAudioDevices[sourceKey].deviceName = shortDeviceName;
             Changed();
             NotifyAudioDevicesChanged(sourceKey);
-            Logger.log?.Debug($"|ADC| Handled \"{sourceKey}\" - \"{deviceName}\"");
+            Logger.log?.Debug($"|ADC| Handled \"{sourceKey}\" - \"{shortDeviceName}\"");
         }
 
         #region Backing Fields

--- a/OBSControl/UI/AudioDeviceDropdownEntry.cs
+++ b/OBSControl/UI/AudioDeviceDropdownEntry.cs
@@ -26,14 +26,14 @@ public class AudioDeviceDropdownEntry
         this.LongKeyName = longKeyName;
         this.IsAvailable = available;
     }
-    public async Task TrySetDevice(string sourceKey, string deviceName)
+    public async Task TrySetDevice(string sourceKey, string shortDeviceName, bool isOutput)
     {
         try
         {
             var audioDevicesController = AudioDevicesController;
             if (audioDevicesController != null)
             {
-                await audioDevicesController.setSourceToDeviceByName(sourceKey, deviceName);
+                await audioDevicesController.setSourceToDeviceByName(sourceKey, shortDeviceName, isOutput);
             }
             else
             {


### PR DESCRIPTION
This stopped working because shortening the device names made some Dictionary keys exist twice for different devices. I had one dictionary that stored inputs and outputs for convenience, but I now completely removed that and everything now specifies output or input. Handling of Sources that we receive from OBS is a bit uglier now, because OBS just gives you one array with inputs and outputs combined, but everything after that should be divided now.